### PR TITLE
updating csp11a.mako with BCCON and BCPROP

### DIFF
--- a/src/pyopmcsp11/templates/co2/csp11a.mako
+++ b/src/pyopmcsp11/templates/co2/csp11a.mako
@@ -67,6 +67,10 @@ PERMX PERMZ /
 
 INCLUDE
 '${dic['exe']}/${dic['fol']}/preprocessing/PORO.INC' /
+
+BCCON 
+1 1 ${dic['noCells'][0]} 1 1 1 1 Z-/
+/
 ----------------------------------------------------------------------------
 PROPS
 ----------------------------------------------------------------------------
@@ -95,10 +99,6 @@ RPTRST
  'BASIC=2' DEN/
 %endif
 
-BC 
-1 ${dic['noCells'][0]} 1 1 1 1 Z- FREE /
-/
-
 % if dic['model'] == 'complete':
 RSVD
 0   0.0
@@ -121,6 +121,10 @@ RPTRST
 % else:
  'BASIC=2' DEN/
 %endif
+
+BCPROP
+ 1 FREE /
+/
 
 WELSPECS
 % for i in range(len(dic['wellijk'])):


### PR DESCRIPTION
BC keyword is replaced by BCCON and BCPROP in OPM-flow master branch.

When I tried to csp11a.txt example, it complains about the BC keyword and can not run. 